### PR TITLE
Bug/#89/passing state context in slu test

### DIFF
--- a/slu/slu/constants/__init__.py
+++ b/slu/slu/constants/__init__.py
@@ -123,6 +123,7 @@ REFERENCE_TIME = "reference_time"
 LOCALE = "locale"
 CURRENT_STATE = "current_state"
 CURRENT_INTENT = "current_intent"
+STATE = "state"
 
 LANG_TO_LOCALES = {"en": "en_IN", "hi": "hi_IN"}  # This should be set via config
 

--- a/slu/slu/dev/test.py
+++ b/slu/slu/dev/test.py
@@ -170,7 +170,7 @@ def test_classifier(args: argparse.Namespace):
         output = predict_api(
             **{
                 const.ALTERNATIVES: json.loads(row[const.ALTERNATIVES]),
-                const.CONTEXT: {},
+                const.CONTEXT: {const.CURRENT_STATE: row[const.STATE]},
                 const.LANG: lang,
                 "ignore_test_case": True,
             }


### PR DESCRIPTION
1. passing state context from **predict_api**` inside slu/dev/test.py`
2. added STATE='state' variables in constants.