### PR TITLE
Num `epochs` as argument support & automating `slu release` changelog updates

### DIFF
--- a/slu/slu/dev/cli.py
+++ b/slu/slu/dev/cli.py
@@ -61,13 +61,18 @@ def build_train_cli(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
         help="The path of a csv dataset containing utterances and labels. If not provided, we look for files in data/<version/classification/datasets.",
     )
     parser.add_argument(
-        "--lang", help="The language code to use for the dataset.", required=True
+        "--lang", help="The language code to use for the dataset."
     )
     parser.add_argument(
         "--project", help="The project scope to which the dataset belongs."
     )
     parser.add_argument(
         "--version", help="The dataset version, which will also be the model's version."
+    )
+    parser.add_argument(
+        "--epochs",
+        help="The number of epochs to train the model for.",
+        type=int,
     )
     return parser
 
@@ -119,6 +124,11 @@ def build_release_cli(parser: argparse.ArgumentParser) -> argparse.ArgumentParse
         "--version",
         required=True,
         help="The version of the dataset, model, metrics to use. Defaults to the latest version.",
+    )
+    parser.add_argument(
+        "--auto",
+        action="store_true",
+        help="Changelog is updated automatically (used for auto retraining)",
     )
     return parser
 

--- a/slu/slu/dev/release.py
+++ b/slu/slu/dev/release.py
@@ -108,7 +108,7 @@ def vcs(repo: Repo, version: str, changelog_body: str, active_branch: str) -> No
     remote.push(tag)
 
 
-def update_changelog(version: str) -> str:
+def update_changelog(version: str, auto: bool) -> str:
     """
     Read user input and update changelog.
 
@@ -120,16 +120,17 @@ def update_changelog(version: str) -> str:
     Returns:
         str: Changelog content.
     """
-    separator = "-" * 50 + "\n"
-    print_formatted_text(
-        HTML(
-            f"What makes version {version} remarkable? "
-            "\nThis input is <b><ansigreen>markdown friendly</ansigreen></b> and <b><ansigreen>date</ansigreen></b> will be added automatically!\n(Press ESC"
-            " followed by ENTER to submit)\n" + separator
+    if not auto:
+        separator = "-" * 50 + "\n"
+        print_formatted_text(
+            HTML(
+                f"What makes version {version} remarkable? "
+                "\nThis input is <b><ansigreen>markdown friendly</ansigreen></b> and <b><ansigreen>date</ansigreen></b> will be added automatically!\n(Press ESC"
+                " followed by ENTER to submit)\n" + separator
+            )
         )
-    )
 
-    raw_changelog = prompt("", multiline=True)
+    raw_changelog = f"Auto-Pushed version {version} after training." if auto else prompt("", multiline=True)
 
     timestamp = datetime.strftime(datetime.now(), "%A, %d %B %Y | %I:%M %p")
     changelog_body = raw_changelog.strip()
@@ -153,6 +154,7 @@ def release(args: argparse.Namespace) -> None:
         version (str): Semver for the dataset, model and metrics.
     """
     version = args.version
+    auto = args.auto
     # Ensure `version` is a valid semver.
     semver.VersionInfo.parse(version)
     project_config_map = YAMLLocalConfig().generate()
@@ -189,7 +191,7 @@ def release(args: argparse.Namespace) -> None:
     check_version_save_config(config, version)
 
     # Maintain changelog.
-    changelog_body = update_changelog(version)
+    changelog_body = update_changelog(version, auto)
 
     # version control commands
     # git and dvc add, commit, push combo.

--- a/slu/slu/dev/train.py
+++ b/slu/slu/dev/train.py
@@ -189,6 +189,7 @@ def merge_datasets(args: argparse.Namespace) -> None:
 def train_intent_classifier(args: argparse.Namespace) -> None:
     version = args.version
     dataset = args.file
+    epochs = args.epochs
     project_config_map = YAMLLocalConfig().generate()
     config: Config = list(project_config_map.values()).pop()
     check_version_save_config(config, version)
@@ -208,7 +209,7 @@ def train_intent_classifier(args: argparse.Namespace) -> None:
             """.strip()
         )
 
-    workflow = SLUPipeline(config).get_workflow(purpose=const.TRAIN)
+    workflow = SLUPipeline(config).get_workflow(purpose=const.TRAIN, epochs=epochs)
 
     logger.info("Preparing dataset.")
     dataset = dataset or config.get_dataset(const.CLASSIFICATION, f"{const.TRAIN}.csv")

--- a/slu/slu/src/controller/processors.py
+++ b/slu/slu/src/controller/processors.py
@@ -16,7 +16,7 @@ class SLUPipeline:
         self.debug = kwargs.get("debug", False)
 
 
-    def get_plugins(self, purpose) -> List[Plugin]:
+    def get_plugins(self, purpose, **kwargs) -> List[Plugin]:
         merge_asr_output = plugins.MergeASROutputPlugin(
             dest="input.clf_feature",
             use_transform=True,
@@ -58,6 +58,7 @@ class SLUPipeline:
             score_round_off=5,
             purpose=purpose,
             use_cuda=purpose != const.PRODUCTION,
+            epochs=kwargs.get(const.EPOCHS),
             data_column=const.ALTERNATIVES,
             label_column=const.TAG,
             args_map=self.config.get_model_args(const.CLASSIFICATION),
@@ -91,8 +92,8 @@ class SLUPipeline:
         return all_plugins
         
 
-    def get_workflow(self, purpose, final_plugin=None):
-        self.plugins = self.get_plugins(purpose)
+    def get_workflow(self, purpose, final_plugin=None, **kwargs):
+        self.plugins = self.get_plugins(purpose, **kwargs)
         if final_plugin:
             self.plugins = self.filter_plugins(self.plugins, final_plugin)
 

--- a/slu/slu/src/controller/processors.py
+++ b/slu/slu/src/controller/processors.py
@@ -58,10 +58,9 @@ class SLUPipeline:
             score_round_off=5,
             purpose=purpose,
             use_cuda=purpose != const.PRODUCTION,
-            epochs=kwargs.get(const.EPOCHS),
             data_column=const.ALTERNATIVES,
             label_column=const.TAG,
-            args_map=self.config.get_model_args(const.CLASSIFICATION),
+            args_map=self.config.get_model_args(const.CLASSIFICATION, purpose, epochs=kwargs.get(const.EPOCHS)),
             debug=self.debug,
         )
 

--- a/slu/slu/utils/config.py
+++ b/slu/slu/utils/config.py
@@ -139,9 +139,13 @@ class Config:
             self._get_data_dir(task_name, version=version), const.DATASETS, file_name
         )
 
-    def get_model_args(self, task_name: str) -> Dict[str, Any]:
+    def get_model_args(self, task_name: str, purpose: str, **kwargs) -> Dict[str, Any]:
         if task_name == const.CLASSIFICATION:
-            return self.tasks.classification.model_args
+            args_map = self.tasks.classification.model_args
+            if purpose == const.TRAIN:
+                if (epochs := kwargs.get(const.EPOCHS)):
+                    args_map[const.TRAIN][const.NUM_TRAIN_EPOCHS] = epochs
+            return args_map
         raise NotImplementedError(f"Model for {task_name} is not defined!")
 
     def get_model_confidence_threshold(self, task_name: str) -> float:


### PR DESCRIPTION
This PR makes the following changes in template:

- `--lang` not a required param for `slu train` anymore.
- `--epochs` (int) as an argument for `slu train`.
- `--auto` a new param for `slu release` to automate changelog updates and releases.