### PR TITLE
add health prefix to probe endpoint

### DIFF
--- a/slu/slu/src/api/endpoints.py
+++ b/slu/slu/src/api/endpoints.py
@@ -36,7 +36,7 @@ if os.environ.get(const.ENVIRONMENT) == const.PRODUCTION:
     app.add_middleware(SentryAsgiMiddleware)
 
 
-@app.get("/{probe_type}")
+@app.get("/health/{probe_type}")
 async def health_check(probe_type, background_tasks: BackgroundTasks):
     """
     Get server status health.


### PR DESCRIPTION
This is needed to avoid errors while Prometheus scrapes for the `/metrics` endpoint.