### PR TITLE
added support for skip intents, aliases and removing empty alternatives

### DIFF
--- a/slu/slu/dev/test.py
+++ b/slu/slu/dev/test.py
@@ -46,8 +46,7 @@ def update_confidence_scores(
     merged_df = pd.merge(test_df, predictions_df, on="data_id")
     valid_inputs = merged_df[~merged_df.alternatives.isin(["[]", "[[]]"])]
     correct_items = valid_inputs[valid_inputs.tag == valid_inputs.intent_pred]
-    incorrect_items = valid_inputs[valid_inputs.tag !=
-                                   valid_inputs.intent_pred]
+    incorrect_items = valid_inputs[valid_inputs.tag != valid_inputs.intent_pred]
     logger.info(f"{correct_items.score.describe()}")
     logger.info(f"{incorrect_items.score.describe()}")
 
@@ -144,11 +143,9 @@ def test_classifier(args: argparse.Namespace):
     config: Config = list(project_config_map.values()).pop()
 
     predict_api = get_predictions(const.TEST, config=config, debug=False)
-    dataset = dataset or config.get_dataset(
-        const.CLASSIFICATION, f"{const.TEST}.csv")
+    dataset = dataset or config.get_dataset(const.CLASSIFICATION, f"{const.TEST}.csv")
     test_df = pd.read_csv(dataset)
-    test_df = test_df[~test_df[const.TAG].isin(
-        config.tasks.classification.skip)]
+    test_df = test_df[~test_df[const.TAG].isin(config.tasks.classification.skip)]
     test_df = test_df[test_df[const.ALTERNATIVES] != "[]"]
     test_df = test_df.replace({const.TAG: config.tasks.classification.alias})
 
@@ -197,5 +194,4 @@ def test_classifier(args: argparse.Namespace):
     make_confusion_matrix(
         zoomed_true_label, zoomed_predicted_label, dir_path=dir_path, prefix="zoomed"
     )
-    make_confusion_matrix(true_labels, pred_labels,
-                          dir_path=dir_path, prefix="full")
+    make_confusion_matrix(true_labels, pred_labels, dir_path=dir_path, prefix="full")

--- a/slu/slu/dev/test.py
+++ b/slu/slu/dev/test.py
@@ -46,7 +46,8 @@ def update_confidence_scores(
     merged_df = pd.merge(test_df, predictions_df, on="data_id")
     valid_inputs = merged_df[~merged_df.alternatives.isin(["[]", "[[]]"])]
     correct_items = valid_inputs[valid_inputs.tag == valid_inputs.intent_pred]
-    incorrect_items = valid_inputs[valid_inputs.tag != valid_inputs.intent_pred]
+    incorrect_items = valid_inputs[valid_inputs.tag !=
+                                   valid_inputs.intent_pred]
     logger.info(f"{correct_items.score.describe()}")
     logger.info(f"{incorrect_items.score.describe()}")
 
@@ -143,8 +144,13 @@ def test_classifier(args: argparse.Namespace):
     config: Config = list(project_config_map.values()).pop()
 
     predict_api = get_predictions(const.TEST, config=config, debug=False)
-    dataset = dataset or config.get_dataset(const.CLASSIFICATION, f"{const.TEST}.csv")
+    dataset = dataset or config.get_dataset(
+        const.CLASSIFICATION, f"{const.TEST}.csv")
     test_df = pd.read_csv(dataset)
+    test_df = test_df[~test_df[const.TAG].isin(
+        config.tasks.classification.skip)]
+    test_df = test_df[test_df[const.ALTERNATIVES] != "[]"]
+    test_df = test_df.replace({const.TAG: config.tasks.classification.alias})
 
     logger.info("Running predictions")
     predictions = []
@@ -191,4 +197,5 @@ def test_classifier(args: argparse.Namespace):
     make_confusion_matrix(
         zoomed_true_label, zoomed_predicted_label, dir_path=dir_path, prefix="zoomed"
     )
-    make_confusion_matrix(true_labels, pred_labels, dir_path=dir_path, prefix="full")
+    make_confusion_matrix(true_labels, pred_labels,
+                          dir_path=dir_path, prefix="full")

--- a/slu/slu/dev/train.py
+++ b/slu/slu/dev/train.py
@@ -39,8 +39,10 @@ def reftime_patterns(reftime: str):
         lambda date_string: datetime.strptime(
             date_string, "%Y-%m-%d %H:%M:%S.%f %z %Z"
         ),
-        lambda date_string: datetime.strptime(date_string, "%Y-%m-%dT%H:%M:%SZ"),
-        lambda date_string: datetime.strptime(date_string, "%Y-%m-%dT%H:%M:%S.%f%z"),
+        lambda date_string: datetime.strptime(
+            date_string, "%Y-%m-%dT%H:%M:%SZ"),
+        lambda date_string: datetime.strptime(
+            date_string, "%Y-%m-%dT%H:%M:%S.%f%z"),
     ]
     for time_fn in time_fns:
         try:
@@ -152,7 +154,8 @@ Data already exists in {dest}
     )
     train.to_csv(os.path.join(dest, f"{const.TRAIN}.csv"), index=False)
     test.to_csv(os.path.join(dest, f"{const.TEST}.csv"), index=False)
-    train_skip_samples.to_csv(os.path.join(dest, f"{const.SKIPPED}.csv"), index=False)
+    train_skip_samples.to_csv(os.path.join(
+        dest, f"{const.SKIPPED}.csv"), index=False)
 
 
 def merge_datasets(args: argparse.Namespace) -> None:
@@ -162,7 +165,8 @@ def merge_datasets(args: argparse.Namespace) -> None:
     data_files = args.files
     file_name = args.out
 
-    data_frames = pd.concat([pd.read_csv(data_file) for data_file in data_files])
+    data_frames = pd.concat([pd.read_csv(data_file)
+                            for data_file in data_files])
     data_frames.to_csv(file_name, index=False)
 
 
@@ -180,11 +184,19 @@ def train_intent_classifier(args: argparse.Namespace) -> None:
             """.strip()
         )
 
-    workflow = SLUPipeline(config).get_workflow(purpose=const.TRAIN, epochs=epochs)
+    workflow = SLUPipeline(config).get_workflow(
+        purpose=const.TRAIN, epochs=epochs)
 
     logger.info("Preparing dataset.")
-    dataset = dataset or config.get_dataset(const.CLASSIFICATION, f"{const.TRAIN}.csv")
+    dataset = dataset or config.get_dataset(
+        const.CLASSIFICATION, f"{const.TRAIN}.csv")
     data_frame = pd.read_csv(dataset)
+    data_frame = data_frame[~data_frame[const.TAG].isin(
+        config.tasks.classification.skip)]
+    data_frame = data_frame.replace(
+        {const.TAG: config.tasks.classification.alias})
+    logger.info(
+        f"Model will be trained for the following classes:\n{data_frame[const.TAG].value_counts(dropna=False)}")
     make_label_column_uniform(data_frame)
     make_data_column_uniform(data_frame)
     make_reftime_column_uniform(data_frame)

--- a/slu/slu/dev/train.py
+++ b/slu/slu/dev/train.py
@@ -119,7 +119,8 @@ Data already exists in {dest}
     # Replacing intents with their alias
     data_frame = data_frame.replace({const.TAG: config.tasks.classification.alias})
     logger.info(
-        f"Model will be trained for the following classes:\n{data_frame[const.TAG].value_counts(dropna=False)}"
+        f"Model will be trained for the following classes:\
+        \n{data_frame[const.TAG].value_counts(dropna=False)}"
     )
     make_label_column_uniform(data_frame)
     make_data_column_uniform(data_frame)

--- a/slu/tests/test_controller/test_predict_api.py
+++ b/slu/tests/test_controller/test_predict_api.py
@@ -46,7 +46,8 @@ def verify_slots(key, predicted_output, expected_output):
         for slot in expected_output[const.INTENTS][0][const.SLOTS]
     }
 
-    assert len(pred_slots) == len(true_slots), f"{key} slot-size doesn't match!"
+    assert len(pred_slots) == len(
+        true_slots), f"{key} slot-size doesn't match!"
     for pred_slot, true_slot in zip(pred_slots, true_slots):
         pred_slot_values = pred_slots[pred_slot][const.VALUES]
         true_slot_values = true_slots[true_slot][const.VALUES]
@@ -138,6 +139,10 @@ def test_classifier_on_training_data(slu_api):
     config: Config = list(project_config_map.values()).pop()
     dataset = config.get_dataset(const.CLASSIFICATION, f"{const.TRAIN}.csv")
     test_df = pd.read_csv(dataset).sample(n=100)
+    test_df = test_df[~test_df[const.TAG].isin(
+        config.tasks.classification.skip)]
+    test_df = test_df[test_df[const.ALTERNATIVES] != "[]"]
+    test_df = test_df.replace({const.TAG: config.tasks.classification.alias})
 
     predictions = []
     config.tasks.classification.threshold = 0

--- a/slu/tests/test_controller/test_predict_api.py
+++ b/slu/tests/test_controller/test_predict_api.py
@@ -46,8 +46,7 @@ def verify_slots(key, predicted_output, expected_output):
         for slot in expected_output[const.INTENTS][0][const.SLOTS]
     }
 
-    assert len(pred_slots) == len(
-        true_slots), f"{key} slot-size doesn't match!"
+    assert len(pred_slots) == len(true_slots), f"{key} slot-size doesn't match!"
     for pred_slot, true_slot in zip(pred_slots, true_slots):
         pred_slot_values = pred_slots[pred_slot][const.VALUES]
         true_slot_values = true_slots[true_slot][const.VALUES]
@@ -139,8 +138,7 @@ def test_classifier_on_training_data(slu_api):
     config: Config = list(project_config_map.values()).pop()
     dataset = config.get_dataset(const.CLASSIFICATION, f"{const.TRAIN}.csv")
     test_df = pd.read_csv(dataset).sample(n=100)
-    test_df = test_df[~test_df[const.TAG].isin(
-        config.tasks.classification.skip)]
+    test_df = test_df[~test_df[const.TAG].isin(config.tasks.classification.skip)]
     test_df = test_df[test_df[const.ALTERNATIVES] != "[]"]
     test_df = test_df.replace({const.TAG: config.tasks.classification.alias})
 


### PR DESCRIPTION
- Re-added support for skip intents, aliases for `slu train`, `slu test` and `make test`/`pytests`.
- Also added support to remove turns with empty alternatives/transcript for  `slu test` and `make test`/`pytests`.
- Empty alternatives were removed because empty alternatives is not SLU’s ownership. Plus, having a lot of turns go into `_error_` causes misinterpretation of the model’s performance, especially when empty turns are not uniformly + randomly distributed among all the intents during tagging.