### PR TITLE
update make_data_column_uniform

### DIFF
--- a/slu/slu/utils/preprocessing.py
+++ b/slu/slu/utils/preprocessing.py
@@ -58,7 +58,7 @@ def make_reftime_column_uniform(data_frame: pd.DataFrame) -> pd.DataFrame:
 
     return data_frame
 
-def make_data_column_uniform(data_frame: pd.DataFrame) -> pd.DataFrame:
+def make_data_column_uniform(data_frame: pd.DataFrame) -> None:
     if const.ALTERNATIVES in data_frame.columns:
         column = const.ALTERNATIVES
     elif const.DATA in data_frame.columns:
@@ -74,9 +74,11 @@ def make_data_column_uniform(data_frame: pd.DataFrame) -> pd.DataFrame:
     ):
         if isinstance(row[const.ALTERNATIVES], str):
             data = json.loads(row[const.ALTERNATIVES])
+            if isinstance(data, str):
+                data = json.loads(row[const.ALTERNATIVES])
             if const.ALTERNATIVES in data:
                 data_frame.loc[i, const.ALTERNATIVES] = json.dumps(
-                    data[const.ALTERNATIVES]
+                    data[const.ALTERNATIVES], ensure_ascii=False
                 )
-
+                
     return data_frame

--- a/slu/slu/utils/preprocessing.py
+++ b/slu/slu/utils/preprocessing.py
@@ -58,7 +58,7 @@ def make_reftime_column_uniform(data_frame: pd.DataFrame) -> pd.DataFrame:
 
     return data_frame
 
-def make_data_column_uniform(data_frame: pd.DataFrame) -> None:
+def make_data_column_uniform(data_frame: pd.DataFrame) -> pd.DataFrame:
     if const.ALTERNATIVES in data_frame.columns:
         column = const.ALTERNATIVES
     elif const.DATA in data_frame.columns:

--- a/slu/slu/utils/preprocessing.py
+++ b/slu/slu/utils/preprocessing.py
@@ -75,7 +75,7 @@ def make_data_column_uniform(data_frame: pd.DataFrame) -> pd.DataFrame:
         if isinstance(row[const.ALTERNATIVES], str):
             data = json.loads(row[const.ALTERNATIVES])
             if isinstance(data, str):
-                data = json.loads(row[const.ALTERNATIVES])
+                data = json.loads(data)
             if const.ALTERNATIVES in data:
                 data_frame.loc[i, const.ALTERNATIVES] = json.dumps(
                     data[const.ALTERNATIVES], ensure_ascii=False

--- a/slu/slu/utils/preprocessing.py
+++ b/slu/slu/utils/preprocessing.py
@@ -74,11 +74,16 @@ def make_data_column_uniform(data_frame: pd.DataFrame) -> pd.DataFrame:
     ):
         if isinstance(row[const.ALTERNATIVES], str):
             data = json.loads(row[const.ALTERNATIVES])
-            if isinstance(data, str):
+            if isinstance(data,str) and data != '':
                 data = json.loads(data)
             if const.ALTERNATIVES in data:
                 data_frame.loc[i, const.ALTERNATIVES] = json.dumps(
-                    data[const.ALTERNATIVES], ensure_ascii=False
+                    data[const.ALTERNATIVES],
+                    ensure_ascii=False
+                )
+            else:
+                data_frame.loc[i, const.ALTERNATIVES] = json.dumps(
+                    data, ensure_ascii=False
                 )
                 
     return data_frame


### PR DESCRIPTION
Ticket: https://vernacular-ai.atlassian.net/browse/CMS-2525
Data path: s3://vodafone-depository/datasets/problematic_datapoints_(production calls).csv)


Problem:
I found that a large amount of production data in Vodafone contains noisy transcripts. 
In these data points, ASR alternatives seemed be dumped twice (double `json.dumps()`). 
The `merge_asr_output` plugin values are incorrect for these datapoints, which eventually passes as input to the model. 
Following is an example of a noisy transcript, and its expected vs actual `merge_asr_output` value. 

Sample transcript:
```
"[[{\"confidence\": 0.6691616, \"transcript\": \"Shikha was never being recorded\"}, {\"confidence\": 0.6227231, \"transcript\": \"dikha was never being recorded\"}, {\"confidence\": 0.6227347, \"transcript\": \"Dekha was never being recorded\"}, {\"confidence\": 0.5426301, \"transcript\": \"Shikha was now being recorded\"}, {\"confidence\": 0.243892, \"transcript\": \"the cow is now being recorded\"}, {\"confidence\": 0.425278, \"transcript\": \"Shekhawat now being recorded\"}, {\"confidence\": 0.5605131, \"transcript\": \"Sikh was never being recorded\"}, {\"confidence\": 0.4961915, \"transcript\": \"dikha was now being recorded\"}, {\"confidence\": 0.5235198, \"transcript\": \"Shikha was never been recorded\"}, {\"confidence\": 0.61963093, \"transcript\": \"Sikho was never being recorded\"}]]"
```
Expected output: 
```
['<s> Shikha was never being recorded </s> <s> dikha was never being recorded </s> <s> Dekha was never being recorded </s> <s> Shikha was now being recorded </s> <s> the cow is now being recorded </s> <s> Shekhawat now being recorded </s> <s> Sikh was never being recorded </s> <s> dikha was now being recorded </s> <s> Shikha was never been recorded </s> <s> Sikho was never being recorded </s>']
```

Actual output:
```
['<s> [[{"confidence": 0.6691616, "transcript": "Shikha was never being recorded"}, {"confidence": 0.6227231, "transcript": "dikha was never being recorded"}, {"confidence": 0.6227347, "transcript": "Dekha was never being recorded"}, {"confidence": 0.5426301, "transcript": "Shikha was now being recorded"}, {"confidence": 0.243892, "transcript": "the cow is now being recorded"}, {"confidence": 0.425278, "transcript": "Shekhawat now being recorded"}, {"confidence": 0.5605131, "transcript": "Sikh was never being recorded"}, {"confidence": 0.4961915, "transcript": "dikha was now being recorded"}, {"confidence": 0.5235198, "transcript": "Shikha was never been recorded"}, {"confidence": 0.61963093, "transcript": "Sikho was never being recorded"}]] </s>']
```
